### PR TITLE
connection tuning

### DIFF
--- a/syslog-ng-es/docker-entrypoint.sh
+++ b/syslog-ng-es/docker-entrypoint.sh
@@ -5,10 +5,12 @@
 export LD_LIBRARY_PATH=/usr/lib/jvm/java-1.8-openjdk/jre/lib/amd64/server:$LD_LIBRARY_PATH
 
 MAX_CONNECTIONS=${MAX_CONNECTIONS:=10}
+LOG_IW_SIZE=$(expr $MAX_CONNECTIONS \* 100)
 
 sed -i "s/ES_SERVER/$ES_SERVER/g" /etc/syslog-ng/syslog-ng.conf
 sed -i "s/ES_CLUSTER/$ES_CLUSTER/g" /etc/syslog-ng/syslog-ng.conf
 sed -i "s/MAX_CONNECTIONS/$MAX_CONNECTIONS/g" /etc/syslog-ng/syslog-ng.conf
+sed -i "s/LOG_IW_SIZE/$LOG_IW_SIZE/g" /etc/syslog-ng/syslog-ng.conf
 
 if [ -z "$RUNTIME_ARGS" ]; then
   export RUNTIME_ARGS="F"

--- a/syslog-ng-es/syslog-ng.conf
+++ b/syslog-ng-es/syslog-ng.conf
@@ -8,10 +8,11 @@ options {
     create_dirs(yes);
     ts_format(iso);
     on-error(drop-property);
+    log_fifo_size(10000);
 };
 
 source s_net {
-    syslog(ip(0.0.0.0), port(601), transport("tcp"), max-connections(MAX_CONNECTIONS));
+    syslog(ip(0.0.0.0), port(601), transport("tcp"), max-connections(MAX_CONNECTIONS), log-iw-size(LOG_IW_SIZE), log-fetch-limit(100), log_msg_size(65535));
     network(ip(0.0.0.0), port(514), transport("udp"), max-connections(MAX_CONNECTIONS));
 };
 


### PR DESCRIPTION
the old connection defaults were causing warnings: 

`WARNING: window sizing for tcp sources were changed in syslog-ng 3.3, the configuration value was divided by the value of max-connections(). The result was too small, clamping to 100 entries. Ensure you have a proper log_fifo_size setting to avoid message loss.; orig_log_iw_size='20', new_log_iw_size='100', min_log_fifo_size='5000'`

The new defaults got rid of that message, and should improve performance

I also recommend we increase the MAX_CONNECTIONS env var from 50 to 100 and add additional nodes to increase the scale group from a count of 4 to 5.  We currently have 450+ devices out there and our setting of '50' on 4 instances would only be serving less than half of them.

We should monitor the newly configured instances closely for CPU or Network overloads, post deploy.